### PR TITLE
Prevent errors on plugin reload

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -169,13 +169,16 @@ local function OnUnload()
     realityCheckWnd:ReleaseHandler("LABORPOWER_CHANGED")
     realityCheckWnd:Show(false)
     realityCheckWnd = nil
-    gameExitFrame.logOutLaborTimer:Show(false)
-    gameExitFrame.logOutLaborTimer:SetText("")
-    gameExitFrame.logOutLaborTimer = nil
-    gameExitFrame.inGameTimer:Show(false)
-    gameExitFrame.inGameTimer:SetText("")
-    gameExitFrame.inGameTimer = nil
-
+    if gameExitFrame.logOutLaborTimer ~= nil then
+        gameExitFrame.logOutLaborTimer:Show(false)
+        gameExitFrame.logOutLaborTimer:SetText("")
+        gameExitFrame.logOutLaborTimer = nil    
+    end
+    if gameExitFrame.inGameTimer ~= nil then
+        gameExitFrame.inGameTimer:Show(false)
+        gameExitFrame.inGameTimer:SetText("")
+        gameExitFrame.inGameTimer = nil    
+    end
 end
 
 reality_check_addon.OnLoad = OnLoad


### PR DESCRIPTION
Plugin is currently causing errors on plugin reload due to `gameExitTimer.inGameTimer` being nil which can seemingly cause problems in other apps, presumably due to how errors are handled within the script sandbox.

These nil checks prevent it, though there's likely a **proper** solution to the issue, which would be worth looking into when it's not 4:30am